### PR TITLE
Handle localStorage errors in knob binding

### DIFF
--- a/script.js
+++ b/script.js
@@ -214,7 +214,11 @@ function bindKnob(id, key, fmt=(v)=>v){
   el.addEventListener('input', ()=>{
     const t = Number(el.value);
     K[key] = t;
-    localStorage.setItem(LS_KEY, JSON.stringify(K));
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify(K));
+    } catch (err) {
+      // Ignore storage errors (e.g. disabled storage)
+    }
     if(out) out.textContent = fmt(t);
     layoutAll();
   });


### PR DESCRIPTION
## Summary
- wrap the knob persistence logic in a try/catch so layout updates even when localStorage is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d037d33a6c83259224553c8f784c3c