### PR TITLE
Sanitize dynamic team and status rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,13 +197,33 @@ const stage=$('#stage'), bg=$('#bg');
 const logo1=$('#logo1'), logo2=$('#logo2');
 const name1=$('#name1'), name2=$('#name2');
 
+const HTML_ESCAPE_MAP = { "&":"&amp;", "<":"&lt;", ">":"&gt;", "\"":"&quot;", "'":"&#39;" };
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const escapeHtml = value => String(value).replace(HTML_ESCAPE_RE, ch=>HTML_ESCAPE_MAP[ch]);
+
 function formatTeamName(name){
-  if(!name) return '';
-  return String(name).trim().split(/\s+/).join('<br>');
+  const trimmed = String(name ?? '').trim();
+  if(!trimmed) return '';
+  return trimmed.split(/\s+/).map(part=>escapeHtml(part)).join('<br>');
 }
 
 const infoDate=$('#infoDate'), infoTime=$('#infoTime'), infoField=$('#infoField'), infoPaese=$('#infoPaese');
 const statusEl=$('#status');
+
+function setStatusMessage(label, color, extraNodes=[]){
+  const nodes=[document.createTextNode(' ')];
+  const badge=document.createElement('span');
+  badge.style.color=color;
+  badge.textContent=label;
+  nodes.push(badge, ...extraNodes);
+  statusEl.replaceChildren(...nodes);
+}
+
+const createStrongText = text => {
+  const el=document.createElement('strong');
+  el.textContent=text;
+  return el;
+};
 
 /* ===== UI (manopole) ===== */
 function bindKnob(id, key, fmt=(v)=>v){
@@ -302,12 +322,19 @@ async function loadAndRender(){
     infoPaese.textContent = resolvePaese(squadra1, opp, '');
 
     layoutAll();
-    statusEl.innerHTML = ` <span style="color:#8ff59a">OK</span> — <strong>${squadra1}</strong> vs <strong>${squadra2}</strong>`;
+    setStatusMessage('OK', '#8ff59a', [
+      document.createTextNode(' — '),
+      createStrongText(squadra1),
+      document.createTextNode(' vs '),
+      createStrongText(squadra2),
+    ]);
   }catch(err){
     console.error(err);
     infoDate.textContent=''; infoTime.textContent=''; infoField.textContent=''; infoPaese.textContent='';
     layoutAll();
-    statusEl.innerHTML = ` <span style="color:#ffd36d">fallback</span> — controlla permessi o pubblicazione`;
+    setStatusMessage('fallback', '#ffd36d', [
+      document.createTextNode(' — controlla permessi o pubblicazione'),
+    ]);
   }
 }
 

--- a/source/script.js
+++ b/source/script.js
@@ -199,12 +199,32 @@ const name1=$('#name1'), name2=$('#name2');
 const infoDate=$('#infoDate'), infoTime=$('#infoTime'), infoField=$('#infoField'), infoPaese=$('#infoPaese');
 const statusEl=$('#status');
 
+const HTML_ESCAPE_MAP = { "&":"&amp;", "<":"&lt;", ">":"&gt;", "\"":"&quot;", "'":"&#39;" };
+const HTML_ESCAPE_RE = /[&<>"']/g;
+const escapeHtml = value => String(value).replace(HTML_ESCAPE_RE, ch=>HTML_ESCAPE_MAP[ch]);
+
 /* ===== Team name formatting: force each word to a new line ===== */
 function formatTeamName(name){
-  if(!name) return '';
+  const trimmed = String(name ?? '').trim();
+  if(!trimmed) return '';
   // Replace one or more spaces with single space, then split and join with <br>
-  return String(name).trim().split(/\s+/).join('<br>');
+  return trimmed.split(/\s+/).map(part=>escapeHtml(part)).join('<br>');
 }
+
+function setStatusMessage(label, color, extraNodes=[]){
+  const nodes=[document.createTextNode(' ')];
+  const badge=document.createElement('span');
+  badge.style.color=color;
+  badge.textContent=label;
+  nodes.push(badge, ...extraNodes);
+  statusEl.replaceChildren(...nodes);
+}
+
+const createStrongText = text => {
+  const el=document.createElement('strong');
+  el.textContent=text;
+  return el;
+};
 
 
 /* ===== UI (manopole) ===== */
@@ -301,12 +321,19 @@ async function loadAndRender(){
     infoPaese.textContent = resolvePaese(squadra1, opp, '');
 
     layoutAll();
-    statusEl.innerHTML = ` <span style="color:#8ff59a">OK</span> — <strong>${squadra1}</strong> vs <strong>${squadra2}</strong>`;
+    setStatusMessage('OK', '#8ff59a', [
+      document.createTextNode(' — '),
+      createStrongText(squadra1),
+      document.createTextNode(' vs '),
+      createStrongText(squadra2),
+    ]);
   }catch(err){
     console.error(err);
     infoDate.textContent=''; infoTime.textContent=''; infoField.textContent=''; infoPaese.textContent='';
     layoutAll();
-    statusEl.innerHTML = ` <span style="color:#ffd36d">fallback</span> — controlla permessi o pubblicazione`;
+    setStatusMessage('fallback', '#ffd36d', [
+      document.createTextNode(' — controlla permessi o pubblicazione'),
+    ]);
   }
 }
 


### PR DESCRIPTION
## Summary
- escape special characters when formatting team names so user-provided values render safely
- build the status banner from DOM nodes instead of raw innerHTML to prevent markup injection

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d046ca5bd48325ba00dfa36573d325