### PR TITLE
Adjust sponsor strip layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,22 +33,18 @@
 
   .sponsor-strip{
     position:absolute; left:0; right:0; bottom:0;
-  codex/add-sponsor-strip-and-render-function-8wjgv6
+    height:var(--sponsorHeightPx,0);
     display:grid; grid-template-columns:repeat(auto-fit, minmax(0, 1fr));
+    grid-auto-rows:1fr;
     gap:var(--sponsorGapPx,16px); padding:var(--sponsorPaddingPx,20px);
-    align-items:center; justify-items:center;
+    align-content:stretch; align-items:stretch; justify-items:center;
     background:#fff;
-    display:grid; grid-template-columns:repeat(6, minmax(0, 1fr));
-    gap:var(--sponsorGapPx,16px); padding:var(--sponsorPaddingPx,20px);
-    align-items:center; justify-items:center;
-    background:linear-gradient(180deg, rgba(11,12,17,0) 0%, rgba(11,12,17,0.88) 28%, rgba(11,12,17,0.95) 100%);
-    backdrop-filter:blur(4px);
- main
   }
   .sponsor-strip:empty{ display:none; }
   .sponsor-strip .sponsor-logo{
-    width:100%; height:auto; max-height:var(--sponsorLogoMaxPx,80px);
-    object-fit:contain; filter:drop-shadow(0 4px 12px rgba(0,0,0,.45));
+    width:100%; height:100%; max-height:var(--sponsorLogoMaxPx,80px);
+    object-fit:contain; background:#fff;
+    filter:drop-shadow(0 4px 12px rgba(0,0,0,.45));
   }
 
   /* Squadre (loghi+nomi) */

--- a/script.js
+++ b/script.js
@@ -42,7 +42,7 @@ const K = {
   QR_TEXT_SCALE:     1.00,
 
   /* Strip sponsor */
-  SPONSOR_LOGO_RATIO:    0.050,
+  SPONSOR_HEIGHT_RATIO:   0.165,
   SPONSOR_PADDING_RATIO: 0.020,
   SPONSOR_GAP_RATIO:     0.010,
 };
@@ -50,6 +50,9 @@ const K = {
 /* nuova chiave LS per applicare SUBITO i default */
 const LS_KEY = 'manifest_tuning_v6';
 try { Object.assign(K, JSON.parse(localStorage.getItem(LS_KEY)||'{}')||{}); } catch {}
+if(typeof K.SPONSOR_HEIGHT_RATIO !== 'number' && typeof K.SPONSOR_LOGO_RATIO === 'number'){
+  K.SPONSOR_HEIGHT_RATIO = K.SPONSOR_LOGO_RATIO;
+}
 
 /* ===== Helpers sheet ===== */
 const gvizCsvURL=(fileId,gid)=>`https://docs.google.com/spreadsheets/d/${fileId}/gviz/tq?gid=${encodeURIComponent(gid)}&headers=1&tqx=out:csv`;
@@ -225,9 +228,12 @@ function layoutSponsors(metrics, scope){
   const strip = scope?.querySelector?.('#sponsorStrip');
   if(!strip) return;
   const { H } = metrics;
-  strip.style.setProperty('--sponsorPaddingPx', `${H * K.SPONSOR_PADDING_RATIO}px`);
+  const height = H * K.SPONSOR_HEIGHT_RATIO;
+  const padding = H * K.SPONSOR_PADDING_RATIO;
+  strip.style.setProperty('--sponsorHeightPx', `${height}px`);
+  strip.style.setProperty('--sponsorPaddingPx', `${padding}px`);
   strip.style.setProperty('--sponsorGapPx', `${H * K.SPONSOR_GAP_RATIO}px`);
-  strip.style.setProperty('--sponsorLogoMaxPx', `${H * K.SPONSOR_LOGO_RATIO}px`);
+  strip.style.setProperty('--sponsorLogoMaxPx', `${Math.max(0, height - padding * 2)}px`);
 }
 
 /* ===== DOM ===== */
@@ -352,7 +358,7 @@ function initKnobs(){
   bindKnob('k_qr_text','QR_TEXT_SCALE', v=>`${v.toFixed(2)}×`);
 
   // Sponsor strip
-  bindKnob('k_sponsor_scale','SPONSOR_LOGO_RATIO', pctH);
+  bindKnob('k_sponsor_scale','SPONSOR_HEIGHT_RATIO', pctH);
   bindKnob('k_sponsor_pad','SPONSOR_PADDING_RATIO', pctH);
 }
 

--- a/source/index.html
+++ b/source/index.html
@@ -33,22 +33,18 @@
 
   .sponsor-strip{
     position:absolute; left:0; right:0; bottom:0;
- codex/add-sponsor-strip-and-render-function-8wjgv6
+    height:var(--sponsorHeightPx,0);
     display:grid; grid-template-columns:repeat(auto-fit, minmax(0, 1fr));
+    grid-auto-rows:1fr;
     gap:var(--sponsorGapPx,16px); padding:var(--sponsorPaddingPx,20px);
-    align-items:center; justify-items:center;
+    align-content:stretch; align-items:stretch; justify-items:center;
     background:#fff;
-    display:grid; grid-template-columns:repeat(6, minmax(0, 1fr));
-    gap:var(--sponsorGapPx,16px); padding:var(--sponsorPaddingPx,20px);
-    align-items:center; justify-items:center;
-    background:linear-gradient(180deg, rgba(11,12,17,0) 0%, rgba(11,12,17,0.88) 28%, rgba(11,12,17,0.95) 100%);
-    backdrop-filter:blur(4px);
- main
   }
   .sponsor-strip:empty{ display:none; }
   .sponsor-strip .sponsor-logo{
-    width:100%; height:auto; max-height:var(--sponsorLogoMaxPx,80px);
-    object-fit:contain; filter:drop-shadow(0 4px 12px rgba(0,0,0,.45));
+    width:100%; height:100%; max-height:var(--sponsorLogoMaxPx,80px);
+    object-fit:contain; background:#fff;
+    filter:drop-shadow(0 4px 12px rgba(0,0,0,.45));
   }
 
   /* Squadre (loghi+nomi) */

--- a/source/script.js
+++ b/source/script.js
@@ -42,7 +42,7 @@ const K = {
   QR_TEXT_SCALE:     1.00,
 
   /* Strip sponsor */
-  SPONSOR_LOGO_RATIO:    0.050,
+  SPONSOR_HEIGHT_RATIO:   0.165,
   SPONSOR_PADDING_RATIO: 0.020,
   SPONSOR_GAP_RATIO:     0.010,
 };
@@ -50,6 +50,9 @@ const K = {
 /* nuova chiave LS per applicare SUBITO i default */
 const LS_KEY = 'manifest_tuning_v6';
 try { Object.assign(K, JSON.parse(localStorage.getItem(LS_KEY)||'{}')||{}); } catch {}
+if(typeof K.SPONSOR_HEIGHT_RATIO !== 'number' && typeof K.SPONSOR_LOGO_RATIO === 'number'){
+  K.SPONSOR_HEIGHT_RATIO = K.SPONSOR_LOGO_RATIO;
+}
 
 /* ===== Helpers sheet ===== */
 const gvizCsvURL=(fileId,gid)=>`https://docs.google.com/spreadsheets/d/${fileId}/gviz/tq?gid=${encodeURIComponent(gid)}&headers=1&tqx=out:csv`;
@@ -225,9 +228,12 @@ function layoutSponsors(metrics, scope){
   const strip = scope?.querySelector?.('#sponsorStrip');
   if(!strip) return;
   const { H } = metrics;
-  strip.style.setProperty('--sponsorPaddingPx', `${H * K.SPONSOR_PADDING_RATIO}px`);
+  const height = H * K.SPONSOR_HEIGHT_RATIO;
+  const padding = H * K.SPONSOR_PADDING_RATIO;
+  strip.style.setProperty('--sponsorHeightPx', `${height}px`);
+  strip.style.setProperty('--sponsorPaddingPx', `${padding}px`);
   strip.style.setProperty('--sponsorGapPx', `${H * K.SPONSOR_GAP_RATIO}px`);
-  strip.style.setProperty('--sponsorLogoMaxPx', `${H * K.SPONSOR_LOGO_RATIO}px`);
+  strip.style.setProperty('--sponsorLogoMaxPx', `${Math.max(0, height - padding * 2)}px`);
 }
 
 /* ===== DOM ===== */
@@ -352,7 +358,7 @@ function initKnobs(){
   bindKnob('k_qr_text','QR_TEXT_SCALE', v=>`${v.toFixed(2)}×`);
 
   // Sponsor strip
-  bindKnob('k_sponsor_scale','SPONSOR_LOGO_RATIO', pctH);
+  bindKnob('k_sponsor_scale','SPONSOR_HEIGHT_RATIO', pctH);
   bindKnob('k_sponsor_pad','SPONSOR_PADDING_RATIO', pctH);
 }
 


### PR DESCRIPTION
## Summary
- stretch the sponsor strip across the entire white area beneath the QR code with a white background
- compute the sponsor strip height from stage metrics and migrate the tuning knob to the new height ratio
- mirror the layout adjustments in the source assets

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da581f4cec8325a4d2a55416df70a0