### PR TITLE
Remove drop shadow from sponsor logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
     width:100%; height:100%; max-height:var(--sponsorLogoMaxPx,80px);
     object-fit:contain;
     background:transparent;
-    filter:drop-shadow(0 4px 12px rgba(0,0,0,.45));
   }
 
   /* Squadre (loghi+nomi) */

--- a/source/index.html
+++ b/source/index.html
@@ -44,7 +44,6 @@
   .sponsor-strip .sponsor-logo{
     width:100%; height:100%; max-height:var(--sponsorLogoMaxPx,80px);
     object-fit:contain; background:#fff;
-    filter:drop-shadow(0 4px 12px rgba(0,0,0,.45));
   }
 
   /* Squadre (loghi+nomi) */


### PR DESCRIPTION
## Summary
- remove the drop shadow filter from sponsor-strip logos in the generated cover markup

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da5d1b0178832591d3d7276cbc470c