### PR TITLE
Add control for sponsor strip rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
   .sponsor-strip{
     position:absolute; left:0; right:0; bottom:0;
     height:var(--sponsorHeightPx,0);
-    display:grid; grid-template-columns:repeat(auto-fit, minmax(0, 1fr));
+    display:grid; grid-template-columns:repeat(var(--sponsorCols, 1), minmax(0, 1fr));
     grid-auto-rows:1fr;
     gap:var(--sponsorGapPx,16px); padding:var(--sponsorPaddingPx,20px);
     align-content:stretch; align-items:stretch; justify-items:center;
@@ -133,6 +133,7 @@
           <div class="group"><strong>Strip sponsor</strong></div>
           <div class="lbl">Altezza loghi</div>         <input id="k_sponsor_scale" type="range" min="0.02" max="0.12" step="0.002"><span class="val"></span>
           <div class="lbl">Padding strip</div>        <input id="k_sponsor_pad"   type="range" min="0.00" max="0.08" step="0.002"><span class="val"></span>
+          <div class="lbl">Righe sponsor</div>        <input id="k_sponsor_rows" type="range" min="1" max="4" step="1"><span class="val"></span>
         </div>
       </details>
 

--- a/script.js
+++ b/script.js
@@ -45,6 +45,7 @@ const K = {
   SPONSOR_HEIGHT_RATIO:   0.165,
   SPONSOR_PADDING_RATIO: 0.020,
   SPONSOR_GAP_RATIO:     0.010,
+  SPONSOR_ROWS:          1,
 };
 
 /* nuova chiave LS per applicare SUBITO i default */
@@ -52,6 +53,9 @@ const LS_KEY = 'manifest_tuning_v6';
 try { Object.assign(K, JSON.parse(localStorage.getItem(LS_KEY)||'{}')||{}); } catch {}
 if(typeof K.SPONSOR_HEIGHT_RATIO !== 'number' && typeof K.SPONSOR_LOGO_RATIO === 'number'){
   K.SPONSOR_HEIGHT_RATIO = K.SPONSOR_LOGO_RATIO;
+}
+if(typeof K.SPONSOR_ROWS !== 'number' || !Number.isFinite(K.SPONSOR_ROWS) || K.SPONSOR_ROWS <= 0){
+  K.SPONSOR_ROWS = 1;
 }
 
 /* ===== Helpers sheet ===== */
@@ -229,6 +233,9 @@ function layoutSponsors(metrics, scope){
   if(!strip) return;
   const { H } = metrics;
   const desiredHeight = H * K.SPONSOR_HEIGHT_RATIO;
+  const rows = Math.max(1, Math.round(K.SPONSOR_ROWS));
+  const logosCount = strip.querySelectorAll('.sponsor-logo').length;
+  const cols = Math.max(1, logosCount ? Math.ceil(logosCount / rows) : 1);
 
   let qrBottom = H;
   let clearance = H * 0.02; // margine base (~2% dell'altezza)
@@ -263,6 +270,7 @@ function layoutSponsors(metrics, scope){
   strip.style.setProperty('--sponsorPaddingPx', `${padding}px`);
   strip.style.setProperty('--sponsorGapPx', `${H * K.SPONSOR_GAP_RATIO}px`);
   strip.style.setProperty('--sponsorLogoMaxPx', `${Math.max(0, height - padding * 2)}px`);
+  strip.style.setProperty('--sponsorCols', `${cols}`);
 }
 
 /* ===== DOM ===== */
@@ -389,6 +397,7 @@ function initKnobs(){
   // Sponsor strip
   bindKnob('k_sponsor_scale','SPONSOR_HEIGHT_RATIO', pctH);
   bindKnob('k_sponsor_pad','SPONSOR_PADDING_RATIO', pctH);
+  bindKnob('k_sponsor_rows','SPONSOR_ROWS', v=>`${v} riga${v===1?'':'e'}`);
 }
 
 /* ===== Load + Render ===== */


### PR DESCRIPTION
## Summary
- add a sponsor rows control to the strip controls and update the CSS grid to use a computed column count
- bind the new SPONSOR_ROWS knob into the layout logic so exports respect the selected rows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba769b7648325a70ef8399e886194