### PR TITLE
Reduce default spacing between team logos

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ const K = {
   VS_X_RATIO:         0.50,
   VS_Y_RATIO:         0.57,
   TEAM_ALONG_RATIO:  -0.015, // -1.5% W
-  TEAM_OFFSET_RATIO:  0.25,  // 25%
+  TEAM_OFFSET_RATIO:  0.20,  // 20%
   TEAM_RAIL_Y_RATIO:  0.018, // +1.8% H
   TEAM_SCALE:         1.00,
   TEAM_Y_EXTRA_RATIO: 0.00,

--- a/source/script.js
+++ b/source/script.js
@@ -11,7 +11,7 @@ const K = {
   VS_X_RATIO:         0.50,
   VS_Y_RATIO:         0.57,
   TEAM_ALONG_RATIO:  -0.015, // -1.5% W
-  TEAM_OFFSET_RATIO:  0.25,  // 25%
+  TEAM_OFFSET_RATIO:  0.20,  // 20%
   TEAM_RAIL_Y_RATIO:  0.018, // +1.8% H
   TEAM_SCALE:         1.00,
   TEAM_Y_EXTRA_RATIO: 0.00,


### PR DESCRIPTION
## Summary
- decrease the default team logo offset so the two crests render closer together
- keep source script in sync with built script defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaa0438948325a3b4e6e6229c12ec