### PR TITLE
Add dynamic sponsor controls driven by logo directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 
       <details class="tuning">
         <summary>⚙️ Manopole</summary>
-        <div class="grid">
+        <div class="grid" id="knobGrid">
           <div class="group"><strong>Squadre (loghi + nomi) — controlli unificati</strong></div>
           <div class="lbl">Angolo squadre</div>        <input id="k_team_angle" type="range" min="-20" max="20" step="0.5"><span class="val"></span>
           <div class="lbl">Rail Y (squadre)</div>      <input id="k_team_rail"  type="range" min="-0.10" max="0.10" step="0.002"><span class="val"></span>
@@ -134,6 +134,8 @@
           <div class="lbl">Altezza loghi</div>         <input id="k_sponsor_scale" type="range" min="0.02" max="0.12" step="0.002"><span class="val"></span>
           <div class="lbl">Padding strip</div>        <input id="k_sponsor_pad"   type="range" min="0.00" max="0.08" step="0.002"><span class="val"></span>
           <div class="lbl">Righe sponsor</div>        <input id="k_sponsor_rows" type="range" min="1" max="4" step="1"><span class="val"></span>
+
+          <div id="sponsorKnobsHeader" class="group"><strong>Selezione sponsor</strong></div>
         </div>
       </details>
 

--- a/logos/sponsor/manifest.json
+++ b/logos/sponsor/manifest.json
@@ -1,0 +1,12 @@
+{
+  "basePath": "logos/sponsor/",
+  "items": [
+    "3M.jpg",
+    "CM.jpg",
+    "dacol.jpg",
+    "mancini.jpg",
+    "mareco.jpg",
+    "smorlesi.jpg",
+    "top.jpg"
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -58,6 +58,10 @@ if(typeof K.SPONSOR_ROWS !== 'number' || !Number.isFinite(K.SPONSOR_ROWS) || K.S
   K.SPONSOR_ROWS = 1;
 }
 
+const SPONSOR_MANIFEST_URL = 'logos/sponsor/manifest.json';
+const SPONSOR_KNOB_STORAGE_KEY = 'manifest_sponsor_knobs_v1';
+const DEFAULT_SPONSOR_REPEAT_MAX = 4;
+
 /* ===== Helpers sheet ===== */
 const gvizCsvURL=(fileId,gid)=>`https://docs.google.com/spreadsheets/d/${fileId}/gviz/tq?gid=${encodeURIComponent(gid)}&headers=1&tqx=out:csv`;
 const pubCsvFromDocEId=(eId,gid)=>`https://docs.google.com/spreadsheets/d/e/${eId}/pub?gid=${encodeURIComponent(gid)}&single=true&output=csv`;
@@ -279,6 +283,253 @@ const stage=$('#stage'), bg=$('#bg');
 const logo1=$('#logo1'), logo2=$('#logo2');
 const name1=$('#name1'), name2=$('#name2');
 const sponsorStrip=$('#sponsorStrip');
+const knobGrid=document.getElementById('knobGrid');
+const sponsorKnobsHeader=document.getElementById('sponsorKnobsHeader');
+
+let sponsorManifest=[];
+const sponsorManifestMap=new Map();
+let sponsorKnobState={};
+let sponsorKnobsDirty=false;
+let pendingSponsorSeed=null;
+let lastLoadedMeta=new Map();
+
+const normalizeSponsorKey=value=>{
+  let key=String(value??'').trim();
+  if(!key) return '';
+  key=key.replace(/\\/g,'/');
+  key=key.replace(/^\.?\//,'');
+  key=key.replace(/^logos\//i,'');
+  key=key.replace(/^sponsor\//i,'');
+  key=key.replace(/^logos\/sponsor\//i,'');
+  key=key.replace(/^sponsor\//i,'');
+  return key.toLowerCase();
+};
+
+const prettifySponsorLabel=file=>{
+  const base=String(file||'').replace(/\\/g,'/').replace(/^.*\//,'').replace(/\.[^.]+$/,'');
+  const spaced=base.replace(/[_-]+/g,' ').replace(/\s+/g,' ').trim();
+  if(!spaced) return base || '';
+  return spaced.replace(/\b\w/g,ch=>ch.toUpperCase());
+};
+
+const normalizeSponsorManifest=data=>{
+  let basePath='logos/sponsor/';
+  let items=data;
+  if(data && typeof data==='object' && !Array.isArray(data)){
+    if(typeof data.basePath==='string') basePath=data.basePath;
+    items=data.items;
+  }
+  if(typeof basePath!=='string' || !basePath) basePath='logos/sponsor/';
+  basePath=basePath.replace(/\\/g,'/');
+  if(!basePath.endsWith('/')) basePath+='/';
+  if(!Array.isArray(items)) return [];
+  const out=[];
+  const seen=new Set();
+  for(const raw of items){
+    let file='';
+    let label='';
+    let explicitSrc='';
+    if(typeof raw==='string'){
+      file=raw;
+    }else if(raw && typeof raw==='object'){
+      file=raw.file || raw.path || raw.name || raw.src || raw.url || '';
+      label=raw.label || raw.title || '';
+      explicitSrc=raw.src || raw.url || '';
+    }
+    file=String(file||'').trim();
+    explicitSrc=String(explicitSrc||'').trim();
+    if(!file && explicitSrc) file=explicitSrc;
+    if(!file) continue;
+    let normalizedFile=String(file).replace(/\\/g,'/').replace(/^\.?\//,'');
+    normalizedFile=normalizedFile.replace(/^logos\/sponsor\//i,'');
+    const id=normalizeSponsorKey(normalizedFile);
+    if(!id || seen.has(id)) continue;
+    seen.add(id);
+    let src=explicitSrc || normalizedFile;
+    if(!/^https?:/i.test(src) && !src.startsWith('data:')){
+      if(!src.startsWith('logos/') && !src.startsWith('./') && !src.startsWith('../')){
+        src=basePath+normalizedFile;
+      }
+    }
+    const friendly=label ? String(label).trim() : prettifySponsorLabel(normalizedFile);
+    out.push({ id, file: normalizedFile, src, label: friendly, inputEl:null, valueEl:null });
+  }
+  return out;
+};
+
+async function fetchSponsorManifest(){
+  try{
+    const res=await fetch(SPONSOR_MANIFEST_URL,{cache:'no-store'});
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data=await res.json();
+    return normalizeSponsorManifest(data);
+  }catch(err){
+    console.error('Sponsor manifest fetch failed', err);
+    return [];
+  }
+}
+
+function loadSponsorKnobState(){
+  try{
+    const raw=localStorage.getItem(SPONSOR_KNOB_STORAGE_KEY);
+    if(!raw) return {};
+    const parsed=JSON.parse(raw);
+    return (parsed && typeof parsed==='object') ? parsed : {};
+  }catch(err){
+    return {};
+  }
+}
+
+function saveSponsorKnobState(){
+  try{
+    localStorage.setItem(SPONSOR_KNOB_STORAGE_KEY, JSON.stringify(sponsorKnobState));
+  }catch(err){
+    // ignore storage errors
+  }
+}
+
+const formatSponsorKnobValue=value=>{
+  const n=Math.max(0, Math.round(Number(value)||0));
+  return `${n}×`;
+};
+
+function computeSponsorLogosFromKnobs(){
+  const logos=[];
+  for(const entry of sponsorManifest){
+    const count=Math.max(0, Math.round(Number(sponsorKnobState[entry.id] ?? 0)));
+    for(let i=0;i<count;i++) logos.push(entry.src);
+  }
+  return logos;
+}
+
+function getMetaSponsorLogos(meta){
+  const raw = meta?.get?.('sponsor_logos') || '';
+  const parts = String(raw).split(/[\n;]+/);
+  const logos = [];
+  for(const part of parts){
+    const trimmed = part.trim();
+    if(!trimmed) continue;
+    const normalized = normalizeLogoUrl(trimmed);
+    if(!normalized) continue;
+    logos.push(normalized);
+  }
+  return logos;
+}
+
+const isKnownSponsorPath=src=> sponsorManifestMap.has(normalizeSponsorKey(src));
+
+function applySponsorSeedFromList(list){
+  if(!Array.isArray(list) || !list.length) return;
+  const counts=new Map();
+  for(const src of list){
+    const key=normalizeSponsorKey(src);
+    const entry=sponsorManifestMap.get(key);
+    if(!entry) continue;
+    const cur=counts.get(entry.id)||0;
+    counts.set(entry.id, cur+1);
+  }
+  let changed=false;
+  for(const entry of sponsorManifest){
+    const next=counts.get(entry.id)||0;
+    if((sponsorKnobState[entry.id] ?? 0)!==next){
+      sponsorKnobState[entry.id]=next;
+      changed=true;
+    }
+    if(entry.inputEl){
+      const maxVal=Number(entry.inputEl.max||DEFAULT_SPONSOR_REPEAT_MAX);
+      if(next>maxVal) entry.inputEl.max=String(next);
+      entry.inputEl.value=String(next);
+    }
+    if(entry.valueEl){
+      entry.valueEl.textContent=formatSponsorKnobValue(next);
+    }
+  }
+  if(changed) saveSponsorKnobState();
+}
+
+function seedSponsorKnobsFromMeta(meta){
+  if(sponsorKnobsDirty) return;
+  const logos=getMetaSponsorLogos(meta);
+  if(!logos.length) return;
+  if(!sponsorManifest.length){
+    pendingSponsorSeed=logos.slice();
+    return;
+  }
+  applySponsorSeedFromList(logos);
+}
+
+async function setupSponsorKnobs(){
+  if(!knobGrid || !sponsorKnobsHeader) return;
+  const manifest=await fetchSponsorManifest();
+  sponsorManifest=manifest;
+  sponsorManifestMap.clear();
+  if(!manifest.length){
+    sponsorKnobsHeader.remove();
+    return;
+  }
+
+  sponsorKnobState=loadSponsorKnobState();
+  if(typeof sponsorKnobState!=='object' || sponsorKnobState===null) sponsorKnobState={};
+
+  for(const entry of manifest){
+    sponsorManifestMap.set(entry.id, entry);
+    sponsorManifestMap.set(normalizeSponsorKey(entry.file), entry);
+    sponsorManifestMap.set(normalizeSponsorKey(entry.src), entry);
+    const noExt=entry.file.replace(/\.[^.]+$/,'');
+    sponsorManifestMap.set(normalizeSponsorKey(noExt), entry);
+  }
+
+  const frag=document.createDocumentFragment();
+  for(const entry of manifest){
+    const stored=Math.max(0, Math.round(Number(sponsorKnobState[entry.id] ?? 0)));
+    sponsorKnobState[entry.id]=stored;
+
+    const labelEl=document.createElement('div');
+    labelEl.className='lbl';
+    labelEl.textContent=entry.label;
+
+    const inputEl=document.createElement('input');
+    inputEl.type='range';
+    inputEl.min='0';
+    inputEl.max=String(DEFAULT_SPONSOR_REPEAT_MAX);
+    inputEl.step='1';
+    inputEl.value=String(stored);
+    inputEl.dataset.sponsorId=entry.id;
+    inputEl.setAttribute('aria-label', `Ripetizioni sponsor ${entry.label}`);
+
+    const valueEl=document.createElement('span');
+    valueEl.className='val';
+    valueEl.textContent=formatSponsorKnobValue(stored);
+
+    inputEl.addEventListener('input', ()=>{
+      const raw=Number(inputEl.value);
+      const next=Math.max(0, Math.round(Number.isFinite(raw)?raw:0));
+      sponsorKnobState[entry.id]=next;
+      sponsorKnobsDirty=true;
+      valueEl.textContent=formatSponsorKnobValue(next);
+      const maxVal=Number(inputEl.max||DEFAULT_SPONSOR_REPEAT_MAX);
+      if(next>maxVal) inputEl.max=String(next);
+      saveSponsorKnobState();
+      renderSponsors(lastLoadedMeta);
+      layoutAll();
+    });
+
+    entry.inputEl=inputEl;
+    entry.valueEl=valueEl;
+
+    frag.append(labelEl, inputEl, valueEl);
+  }
+
+  knobGrid.insertBefore(frag, sponsorKnobsHeader.nextSibling);
+
+  if(Array.isArray(pendingSponsorSeed) && pendingSponsorSeed.length){
+    applySponsorSeedFromList(pendingSponsorSeed);
+    pendingSponsorSeed=null;
+  }
+
+  renderSponsors(lastLoadedMeta);
+  layoutAll();
+}
 
 const HTML_ESCAPE_MAP = { "&":"&amp;", "<":"&lt;", ">":"&gt;", "\"":"&quot;", "'":"&#39;" };
 const HTML_ESCAPE_RE = /[&<>"']/g;
@@ -296,15 +547,14 @@ const statusEl=$('#status');
 function renderSponsors(meta){
   if(!sponsorStrip) return;
   sponsorStrip.replaceChildren();
-  const raw = meta?.get?.('sponsor_logos') || '';
-  const parts = String(raw).split(/[\n;]+/);
-  const logos = [];
-  for(const part of parts){
-    const trimmed = part.trim();
-    if(!trimmed) continue;
-    const normalized = normalizeLogoUrl(trimmed);
-    if(!normalized) continue;
-    logos.push(normalized);
+
+  const manualLogos = computeSponsorLogosFromKnobs();
+  const metaLogos = getMetaSponsorLogos(meta);
+  let logos = manualLogos.length ? manualLogos.slice() : metaLogos.slice();
+
+  if(manualLogos.length && metaLogos.length){
+    const extras = metaLogos.filter(src => !isKnownSponsorPath(src));
+    if(extras.length) logos = logos.concat(extras);
   }
 
   logos.forEach((src, idx)=>{
@@ -410,6 +660,8 @@ async function loadAndRender(){
     ]);
     const meta = normalizeMeta(metaRows);
     const opp  = normalizeOpp(oppRows);
+    lastLoadedMeta = meta;
+    seedSponsorKnobsFromMeta(meta);
 
     if (!bg.complete) await new Promise(r => { bg.onload=r; bg.onerror=r; });
 
@@ -446,8 +698,9 @@ async function loadAndRender(){
     ]);
   }catch(err){
     console.error(err);
+    lastLoadedMeta = new Map();
     infoDate.textContent=''; infoTime.textContent=''; infoField.textContent=''; infoPaese.textContent='';
-    renderSponsors(new Map());
+    renderSponsors(null);
     layoutAll();
     setStatusMessage('fallback', '#ffd36d', [
       document.createTextNode(' — controlla permessi o pubblicazione'),
@@ -489,9 +742,14 @@ async function downloadPNG(){
 }
 
 /* ===== Wireup ===== */
-window.addEventListener('DOMContentLoaded', ()=>{
+window.addEventListener('DOMContentLoaded', async ()=>{
   document.querySelector('#btnRefresh').addEventListener('click', loadAndRender, { passive:true });
   document.querySelector('#btnDownload').addEventListener('click', downloadPNG, { passive:true });
+  try{
+    await setupSponsorKnobs();
+  }catch(err){
+    console.error('setupSponsorKnobs failed', err);
+  }
   initKnobs();
   loadAndRender();
   const ro = new ResizeObserver(()=> layoutAll());

--- a/source/index.html
+++ b/source/index.html
@@ -34,7 +34,7 @@
   .sponsor-strip{
     position:absolute; left:0; right:0; bottom:0;
     height:var(--sponsorHeightPx,0);
-    display:grid; grid-template-columns:repeat(auto-fit, minmax(0, 1fr));
+    display:grid; grid-template-columns:repeat(var(--sponsorCols, 1), minmax(0, 1fr));
     grid-auto-rows:1fr;
     gap:var(--sponsorGapPx,16px); padding:var(--sponsorPaddingPx,20px);
     align-content:stretch; align-items:stretch; justify-items:center;
@@ -43,7 +43,8 @@
   .sponsor-strip:empty{ display:none; }
   .sponsor-strip .sponsor-logo{
     width:100%; height:100%; max-height:var(--sponsorLogoMaxPx,80px);
-    object-fit:contain; background:#fff;
+    object-fit:contain;
+    background:transparent;
   }
 
   /* Squadre (loghi+nomi) */
@@ -52,16 +53,16 @@
     transform: translate(-50%, -50%) rotate(var(--angle,0deg)); transform-origin:center center;
   }
   .side .logo{ display:block; object-fit:contain; width:var(--logoWpx,200px); height:var(--logoHpx,200px); filter:drop-shadow(0 4px 14px rgba(0,0,0,.45)); }
-  .side .team-name{
+  .side .team-name{ display:inline-block; text-align:center; line-height:1.05; 
     margin-top:var(--nameGapPx,12px); font-family:"Oswald", Arial, sans-serif!important; font-weight:700; text-transform:uppercase;
-    color:#fff; white-space:nowrap; font-size:var(--nameFontPx,40px); -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+    color:#fff; white-space:normal; font-size:var(--nameFontPx,40px); -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
   }
 
   /* Info (righe indipendenti) */
   .info-line{
     position:absolute; transform: translate(-50%, -50%) rotate(var(--angle,0deg)); transform-origin:center;
     font-family:"Oswald", Arial, sans-serif!important; font-weight:700; text-transform:uppercase;
-    color:#fff; white-space:nowrap; font-size:var(--fontPx,36px);
+    color:#fff; white-space: nowrap; font-size:var(--fontPx,36px);
   }
 
   /* QR block (senza freccia) */
@@ -92,7 +93,7 @@
 
       <details class="tuning">
         <summary>⚙️ Manopole</summary>
-        <div class="grid">
+        <div class="grid" id="knobGrid">
           <div class="group"><strong>Squadre (loghi + nomi) — controlli unificati</strong></div>
           <div class="lbl">Angolo squadre</div>        <input id="k_team_angle" type="range" min="-20" max="20" step="0.5"><span class="val"></span>
           <div class="lbl">Rail Y (squadre)</div>      <input id="k_team_rail"  type="range" min="-0.10" max="0.10" step="0.002"><span class="val"></span>
@@ -132,6 +133,9 @@
           <div class="group"><strong>Strip sponsor</strong></div>
           <div class="lbl">Altezza loghi</div>         <input id="k_sponsor_scale" type="range" min="0.02" max="0.12" step="0.002"><span class="val"></span>
           <div class="lbl">Padding strip</div>        <input id="k_sponsor_pad"   type="range" min="0.00" max="0.08" step="0.002"><span class="val"></span>
+          <div class="lbl">Righe sponsor</div>        <input id="k_sponsor_rows" type="range" min="1" max="4" step="1"><span class="val"></span>
+
+          <div id="sponsorKnobsHeader" class="group"><strong>Selezione sponsor</strong></div>
         </div>
       </details>
 


### PR DESCRIPTION
## Summary
- add an in-page manifest loader that builds sponsor knobs from the `logos/sponsor` folder
- persist per-sponsor selections, sync them with the sheet, and update rendering/layout accordingly
- publish a JSON manifest of sponsor logos so the client can discover available assets

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dbb1742d60832589ce762f6fc1a351