### PR TITLE
Fix team block alignment for multi-line names

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
   /* Squadre (loghi+nomi) */
   .side{
     position:absolute; display:flex; flex-direction:column; align-items:center;
-    transform: translate(-50%, -50%) rotate(var(--angle,0deg)); transform-origin:center center;
+    transform: translate(-50%, calc(-50% + var(--teamCenterAdjustPx, 0px))) rotate(var(--angle,0deg));
+    transform-origin:center center;
   }
   .side .logo{ display:block; object-fit:contain; width:var(--logoWpx,200px); height:var(--logoHpx,200px); filter:drop-shadow(0 4px 14px rgba(0,0,0,.45)); }
   .side .team-name{ display:inline-block; text-align:center; line-height:1.05; 

--- a/script.js
+++ b/script.js
@@ -176,6 +176,17 @@ function layoutSide(sideEl, metrics, cx, cy, scale=1){
   sideEl.style.setProperty('--logoWpx', `${logoH}px`);
   sideEl.style.setProperty('--nameGapPx', `${nameGap}px`);
   sideEl.style.setProperty('--nameFontPx', `${nameFont}px`);
+
+  let adjustPx = 0;
+  const nameEl = sideEl.querySelector?.('.team-name');
+  if(nameEl){
+    const rect = nameEl.getBoundingClientRect?.();
+    const nameHeight = rect && Number.isFinite(rect.height) ? rect.height : 0;
+    if(nameHeight > 0 || nameGap > 0){
+      adjustPx = -0.5 * (nameGap + nameHeight);
+    }
+  }
+  sideEl.style.setProperty('--teamCenterAdjustPx', `${adjustPx}px`);
 }
 
 function layoutTeams(metrics, scope){

--- a/source/index.html
+++ b/source/index.html
@@ -50,7 +50,8 @@
   /* Squadre (loghi+nomi) */
   .side{
     position:absolute; display:flex; flex-direction:column; align-items:center;
-    transform: translate(-50%, -50%) rotate(var(--angle,0deg)); transform-origin:center center;
+    transform: translate(-50%, calc(-50% + var(--teamCenterAdjustPx, 0px))) rotate(var(--angle,0deg));
+    transform-origin:center center;
   }
   .side .logo{ display:block; object-fit:contain; width:var(--logoWpx,200px); height:var(--logoHpx,200px); filter:drop-shadow(0 4px 14px rgba(0,0,0,.45)); }
   .side .team-name{ display:inline-block; text-align:center; line-height:1.05; 

--- a/source/script.js
+++ b/source/script.js
@@ -176,6 +176,17 @@ function layoutSide(sideEl, metrics, cx, cy, scale=1){
   sideEl.style.setProperty('--logoWpx', `${logoH}px`);
   sideEl.style.setProperty('--nameGapPx', `${nameGap}px`);
   sideEl.style.setProperty('--nameFontPx', `${nameFont}px`);
+
+  let adjustPx = 0;
+  const nameEl = sideEl.querySelector?.('.team-name');
+  if(nameEl){
+    const rect = nameEl.getBoundingClientRect?.();
+    const nameHeight = rect && Number.isFinite(rect.height) ? rect.height : 0;
+    if(nameHeight > 0 || nameGap > 0){
+      adjustPx = -0.5 * (nameGap + nameHeight);
+    }
+  }
+  sideEl.style.setProperty('--teamCenterAdjustPx', `${adjustPx}px`);
 }
 
 function layoutTeams(metrics, scope){


### PR DESCRIPTION
## Summary
- measure rendered team name height when laying out each side and compute a corrective offset
- apply the offset in CSS so team logos and the VS anchor remain aligned even with wrapped names
- mirror the runtime and markup changes inside the `source/` directory

## Testing
- python3 -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68dbcd4fda388325a85e9f672b57bd3f